### PR TITLE
Add mongodb datastore

### DIFF
--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -37,6 +37,7 @@ module.exports = {
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
   },
+  datastore:'mongodb'
 
 };
 

--- a/config/datastores.js
+++ b/config/datastores.js
@@ -32,7 +32,7 @@ module.exports.datastores = {
   *                                                                          *
   ***************************************************************************/
 
-  default: {
+  mongodb: {
 
     /***************************************************************************
     *                                                                          *
@@ -48,8 +48,8 @@ module.exports.datastores = {
     *    (See https://sailsjs.com/config/datastores for help.)                 *
     *                                                                          *
     ***************************************************************************/
-    // adapter: 'sails-mysql',
-    // url: 'mysql://user:password@host:port/database',
+    adapter: require('sails-mongo'),
+    url: 'mongodb://localhost:27017/codeblobs',
 
   },
 

--- a/config/models.js
+++ b/config/models.js
@@ -71,7 +71,7 @@ module.exports.models = {
   attributes: {
     createdAt: { type: 'number', autoCreatedAt: true, },
     updatedAt: { type: 'number', autoUpdatedAt: true, },
-    id: { type: 'number', autoIncrement: true, },
+    id: { type: 'string', columnName: '_id' },
     //--------------------------------------------------------------------------
     //  /\   Using MongoDB?
     //  ||   Replace `id` above with this instead:

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,6 +291,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "bson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -506,6 +516,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
       "version": "3.4.4",
@@ -806,6 +821,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2036,6 +2056,25 @@
         "minimist": "^1.2.5"
       }
     },
+    "mongodb": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.25.tgz",
+      "integrity": "sha1-07JdrQDtor38vJliELoIKsaGprY=",
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.9",
+        "readable-stream": "2.1.5"
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.9.tgz",
+      "integrity": "sha1-hapx7k+3FhluBreHVXvxOfgB2vU=",
+      "requires": {
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2357,6 +2396,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2492,6 +2536,27 @@
         "read-pkg": "^1.0.0"
       }
     },
+    "readable-stream": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+      "requires": {
+        "buffer-shims": "^1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -2551,6 +2616,22 @@
       "requires": {
         "captains-log": "^2.0.2",
         "switchback": "^2.0.1"
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+        }
       }
     },
     "resolve": {
@@ -6285,6 +6366,42 @@
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        }
+      }
+    },
+    "sails-mongo": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sails-mongo/-/sails-mongo-1.2.0.tgz",
+      "integrity": "sha512-waDWSWM1hOLsiAJ+/eJoMKU9xcMs2yaIfZfnX9p9IV0uU3o75xa5RbY+YZLoN+E20XpfFCCzZBgzvcH02t8uZQ==",
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "async": "2.0.1",
+        "flaverr": "1.1.1",
+        "machine": "^15.0.0",
+        "mongodb": "2.2.25",
+        "qs": "6.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "requires": {
+            "lodash": "^4.8.0"
+          }
+        },
+        "flaverr": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/flaverr/-/flaverr-1.1.1.tgz",
+          "integrity": "sha1-x9XWD5HB/S8DOwZr7NovSHNsFv8=",
+          "requires": {
+            "@sailshq/lodash": "^3.10.2"
+          }
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
-    "sails": "^1.2.4",
+    "@sailshq/connect-redis": "^3.2.1",
+    "@sailshq/lodash": "^3.10.3",
+    "@sailshq/socket.io-redis": "^5.2.0",
     "grunt": "1.0.4",
+    "sails": "^1.2.4",
     "sails-hook-grunt": "^4.0.0",
     "sails-hook-orm": "^2.1.1",
     "sails-hook-sockets": "^2.0.0",
-    "@sailshq/connect-redis": "^3.2.1",
-    "@sailshq/socket.io-redis": "^5.2.0",
-    "@sailshq/lodash": "^3.10.3"
+    "sails-mongo": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "5.16.0"


### PR DESCRIPTION
This PR changes the db store from sails-disk to mongoDB

Related to [#25](https://github.com/MLH-Fellowship/babel-sandbox/issues/25)

### To test:
 - Ensure mongodb is installed
 - `npm install -g sails` if you haven't already
 - `npm install` dependencies
 -  Run `sails lift`
 - Open Postman
 - Create a new POST request
 - Enter `http://localhost:1337/api/v1/config/update` and click **Send**
#### Expected:
status 200 and `OK` in response body