### PR TITLE
add json parsing

### DIFF
--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -1,6 +1,4 @@
 const { Snippet } = require("../../../snippet");
-const UglifyJS = require("uglify-js");
-const { config } = require("grunt");
 const crypto = require("crypto");
 module.exports = {
   friendlyName: "Create new blob test",
@@ -69,8 +67,6 @@ module.exports = {
       configIDs.push(newConfig.id);
     }
 
-    sails.log(configIDs);
-
     // Add configs to blob collection if not already present
     await Blobs.addToCollection(newBlob.id, "configs").members(configIDs);
 
@@ -86,10 +82,7 @@ module.exports = {
       );
     });
 
-
     // TODO: Add a return; problem: the fields "source" and "plugin" show up as null :(
-    // return {
-    //   blob: newBlob
-    // }
+    return { blob: newBlob };
   },
 };

--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -1,23 +1,23 @@
 const { Snippet } = require('../../../snippet');
-const  UglifyJS = require("uglify-js");
+const  UglifyJS = require('uglify-js');
 const { config } = require('grunt');
 
 module.exports = {
-  friendlyName: "create new blob test friendly name",
+  friendlyName: 'create new blob test friendly name',
 
   description:
-    "new blob test name",
+    'new blob test name',
 
   inputs: {
 
     sourceCode: {
       type: {},
-      description: "Source code",
+      description: 'Source code',
       required: true,
     },
     pluginSource: {
       type: {},
-      description: "plugin Code",
+      description: 'plugin Code',
       required: true,
     },
     configs: {
@@ -34,17 +34,17 @@ module.exports = {
 
   exits: {
     success: {
-      outputDescription: "The newly created `Blob`.",
+      outputDescription: 'The newly created `Blob`.',
     },
   },
 
   fn: async ({sourceCode, pluginSource,configs}) => {
-    console.log("Creating something");
-    console.log(sourceCode.description)
-    console.log(pluginSource.description)
+    console.log('Creating something');
+    console.log(sourceCode.description);
+    console.log(pluginSource.description);
     console.log(configs[0].description);
     console.log(configs[1].description);
-    
+
     // var newBlob = await Blobs.create({
     //   testString: testString
     // }).fetch();

--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -1,3 +1,7 @@
+const { Snippet } = require('../../../snippet');
+const  UglifyJS = require("uglify-js");
+const { config } = require('grunt');
+
 module.exports = {
   friendlyName: "create new blob test friendly name",
 
@@ -6,37 +10,47 @@ module.exports = {
 
   inputs: {
 
-    // Input is a test field to make sure stuff is added to database
-    testString: {
-      type: "string",
-      description: "Test string input to test POST",
+    sourceCode: {
+      type: {},
+      description: "Source code",
       required: true,
     },
+    pluginSource: {
+      type: {},
+      description: "plugin Code",
+      required: true,
+    },
+    configs: {
+      description: 'An array of configs',
+      type: [
+        {
+          description: 'string',
+        }
+      ],
+      required: true
+    }
 
   },
 
   exits: {
     success: {
       outputDescription: "The newly created `Blob`.",
-      outputExample: {},
-    },
-
-    // Test error messages
-    noString: {
-      description: "No string was attached.",
-      responseType: "badRequest",
     },
   },
 
-  fn: async ({testString}) => {
+  fn: async ({sourceCode, pluginSource,configs}) => {
     console.log("Creating something");
+    console.log(sourceCode.description)
+    console.log(pluginSource.description)
+    console.log(configs[0].description);
+    console.log(configs[1].description);
     
-    var newBlob = await Blobs.create({
-      testString: testString
-    }).fetch();
+    // var newBlob = await Blobs.create({
+    //   testString: testString
+    // }).fetch();
 
-    return {
-      blob: newBlob,
-    };
+    // return {
+    //   blob: newBlob,
+    // };
   },
 };

--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -1,56 +1,86 @@
-const { Snippet } = require('../../../snippet');
-const  UglifyJS = require('uglify-js');
-const { config } = require('grunt');
-
+const { Snippet } = require("../../../snippet");
+const UglifyJS = require("uglify-js");
+const { config } = require("grunt");
 module.exports = {
-  friendlyName: 'create new blob test friendly name',
+  friendlyName: "Create new blob test",
 
-  description:
-    'new blob test name',
+  description: "This is an action to add a new blob",
 
   inputs: {
-
-    sourceCode: {
+    source: {
       type: {},
-      description: 'Source code',
+      description: "Source code",
       required: true,
     },
-    pluginSource: {
+    plugin: {
       type: {},
-      description: 'plugin Code',
+      description: "Plugin Code",
       required: true,
     },
     configs: {
-      description: 'An array of configs',
+      description: "An array of configs",
       type: [
         {
-          description: 'string',
-        }
+          // descripton is the FIELD "description" with TYPE "string" in the request body
+          description: "string",
+        },
       ],
-      required: true
-    }
-
+      required: true,
+    },
   },
 
   exits: {
     success: {
-      outputDescription: 'The newly created `Blob`.',
+      outputDescription: "The newly created `Blob`.",
     },
   },
 
-  fn: async ({sourceCode, pluginSource,configs}) => {
-    console.log('Creating something');
-    console.log(sourceCode.description);
-    console.log(pluginSource.description);
-    console.log(configs[0].description);
-    console.log(configs[1].description);
+  fn: async ({ source, plugin, configs }) => {
+    sails.log("Creating blob");
 
-    // var newBlob = await Blobs.create({
-    //   testString: testString
-    // }).fetch();
+    // Base64 is used to check if the plugin
+    // or source code or config exists
+    const blobSnippet = new Snippet(
+      source.description,
+      plugin.description,
+      configs.map(({ description }) => description)
+    );
+    const sourceBase64 = Snippet.ID(source.description);
+    const pluginBase64 = Snippet.ID(plugin.description);
+    const blobBase64 = blobSnippet.Link();
 
+    // Check for Blob and add if not present
+    const newBlob = await Blobs.findOrCreate(
+      { base64BlobKey: blobBase64 },
+      { base64BlobKey: blobBase64 }
+    );
+
+    // Check for Plugin and add if not present
+    const newPlugin = await Plugin.findOrCreate(
+      { base64PluginKey: pluginBase64 },
+      { base64PluginKey: pluginBase64, description: plugin.description }
+    );
+
+    // Check for Source and add if not present
+    const newSource = await Source.findOrCreate(
+      { base64SourceKey: sourceBase64 },
+      { base64SourceKey: sourceBase64, description: source.description }
+    );
+
+    await Blobs.update(
+      { id: newBlob.id },
+      { source: newSource.id, plugin: newPlugin.id }
+    ).exec(function (err, blob) {
+      sails.log(
+        err
+          ? `Error creating new blob: ${err}`
+          : `Successfully created new blob`
+      );
+    });
+
+    // TODO: Add a return; problem: the fields "source" and "plugin" show up as null :(
     // return {
-    //   blob: newBlob,
-    // };
+    //   blob: newBlob
+    // }
   },
 };

--- a/api/controllers/blobs/view.js
+++ b/api/controllers/blobs/view.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   fn: async (inputs) => {
-    console.log('Viewing something');
+    sails.log('Viewing all blobs');
     const blobs = await Blobs.find();
     return blobs;
   },

--- a/api/controllers/blobs/view.js
+++ b/api/controllers/blobs/view.js
@@ -1,21 +1,21 @@
 module.exports = {
-  friendlyName: "TestFriendlyName",
-  description: "Test description",
+  friendlyName: 'TestFriendlyName',
+  description: 'Test description',
   inputs: {
 
   },
 
   exits: {
     success: {
-      outputDescription: "Test output description",
-      outputType: "ref",
+      outputDescription: 'Test output description',
+      outputType: 'ref',
     },
-    forbidden: { responseType: "forbidden" },
-    notFound: { responseType: "notFound" },
+    forbidden: { responseType: 'forbidden' },
+    notFound: { responseType: 'notFound' },
   },
 
   fn: async (inputs) => {
-    console.log("Viewing something");
+    console.log('Viewing something');
     const blobs = await Blobs.find();
     return blobs;
   },

--- a/api/controllers/config/view.js
+++ b/api/controllers/config/view.js
@@ -1,0 +1,22 @@
+module.exports = {
+  friendlyName: 'TestFriendlyName',
+  description: 'Test description',
+  inputs: {
+
+  },
+
+  exits: {
+    success: {
+      outputDescription: 'Test output description',
+      outputType: 'ref',
+    },
+    forbidden: { responseType: 'forbidden' },
+    notFound: { responseType: 'notFound' },
+  },
+
+  fn: async (inputs) => {
+    console.log('Viewing all configs');
+    const configs = await Config.find();
+    return configs;
+  },
+};

--- a/api/controllers/config/view.js
+++ b/api/controllers/config/view.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   fn: async (inputs) => {
-    console.log('Viewing all configs');
+    sails.log('Viewing all configs');
     const configs = await Config.find();
     return configs;
   },

--- a/api/controllers/plugin/view.js
+++ b/api/controllers/plugin/view.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   fn: async (inputs) => {
-    console.log('Viewing all plugins');
+    sails.log('Viewing all plugins');
     const plugins = await Plugin.find();
     return plugins;
   },

--- a/api/controllers/plugin/view.js
+++ b/api/controllers/plugin/view.js
@@ -1,0 +1,22 @@
+module.exports = {
+  friendlyName: 'TestFriendlyName',
+  description: 'Test description',
+  inputs: {
+
+  },
+
+  exits: {
+    success: {
+      outputDescription: 'Test output description',
+      outputType: 'ref',
+    },
+    forbidden: { responseType: 'forbidden' },
+    notFound: { responseType: 'notFound' },
+  },
+
+  fn: async (inputs) => {
+    console.log('Viewing all plugins');
+    const plugins = await Plugin.find();
+    return plugins;
+  },
+};

--- a/api/controllers/source/view.js
+++ b/api/controllers/source/view.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   fn: async (inputs) => {
-    console.log('Viewing all sources');
+    sails.log('Viewing all sources');
     const sources = await Source.find();
     return sources;
   },

--- a/api/controllers/source/view.js
+++ b/api/controllers/source/view.js
@@ -1,0 +1,22 @@
+module.exports = {
+  friendlyName: 'TestFriendlyName',
+  description: 'Test description',
+  inputs: {
+
+  },
+
+  exits: {
+    success: {
+      outputDescription: 'Test output description',
+      outputType: 'ref',
+    },
+    forbidden: { responseType: 'forbidden' },
+    notFound: { responseType: 'notFound' },
+  },
+
+  fn: async (inputs) => {
+    console.log('Viewing all sources');
+    const sources = await Source.find();
+    return sources;
+  },
+};

--- a/api/models/Blobs.js
+++ b/api/models/Blobs.js
@@ -21,12 +21,12 @@ module.exports = {
     //  ╠═╣╚═╗╚═╗║ ║║  ║╠═╣ ║ ║║ ║║║║╚═╗
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
-    // One way assocaition (see file:api/models/Source.js)
+    // One way assocaition
     source: {
       model:'source',
     },
 
-    // One way association (see file:api/models/Plugin.js)
+    // One way association
     plugin: {
       model:'plugin'
     },

--- a/api/models/Blobs.js
+++ b/api/models/Blobs.js
@@ -11,10 +11,7 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
-    blob: { type: "json" },
-
-    // This is a test field to ensure stuff is being added
-    testString: { type: "string" },
+    base64ID: { type:'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/api/models/Blobs.js
+++ b/api/models/Blobs.js
@@ -11,7 +11,7 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
-    base64ID: { type:'string' },
+    base64BlobKey: { type:'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
@@ -21,23 +21,21 @@ module.exports = {
     //  ╠═╣╚═╗╚═╗║ ║║  ║╠═╣ ║ ║║ ║║║║╚═╗
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
-    // One-to-One (see file:api/models/Source.js)
+    // One way assocaition (see file:api/models/Source.js)
     source: {
-      collection:'source',
-      via: 'blobKey'
+      model:'source',
     },
 
-    // One-to-One (see file:api/models/Plugin.js)
+    // One way association (see file:api/models/Plugin.js)
     plugin: {
-      collection:'plugin',
-      via: 'blobKey'
+      model:'plugin'
     },
 
     // One-to-Many (see file:api/models/Config.js)
     configs: {
-      collection: "config",
-      via: "configKey",
+      collection: 'config',
+      via: 'blobKey',
     },
   },
-  datastore: "mongodb",
+  datastore: 'mongodb',
 };

--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -13,6 +13,7 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
+    description: { type: 'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
@@ -24,7 +25,7 @@ module.exports = {
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
     // Other side of One-to-Many
-    configKey: {
+    blobKey: {
       model: 'blobs'
     }
 

--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -13,7 +13,7 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
-    description: { type: 'string' },
+    base64ConfigKey: { type: 'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/api/models/Plugin.js
+++ b/api/models/Plugin.js
@@ -13,7 +13,6 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
-    description: { type: 'string' },
     base64PluginKey: { type: 'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗

--- a/api/models/Plugin.js
+++ b/api/models/Plugin.js
@@ -13,24 +13,18 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
+    description: { type: 'string' },
+    base64PluginKey: { type: 'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
     //  ╚═╝╩ ╩╚═╝╚═╝═╩╝╚═╝
 
-
     //  ╔═╗╔═╗╔═╗╔═╗╔═╗╦╔═╗╔╦╗╦╔═╗╔╗╔╔═╗
     //  ╠═╣╚═╗╚═╗║ ║║  ║╠═╣ ║ ║║ ║║║║╚═╗
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
-    // Other side of One-to-One
-    blobKey:{
-      model:'blobs',
-      unique: true
-    }
-
   },
-  datastore: "mongodb",
-
+  datastore: 'mongodb',
 };
 

--- a/api/models/Source.js
+++ b/api/models/Source.js
@@ -6,10 +6,15 @@
  */
 
 module.exports = {
+
   attributes: {
+
     //  ╔═╗╦═╗╦╔╦╗╦╔╦╗╦╦  ╦╔═╗╔═╗
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
+
+    description: { type: 'string' },
+    base64SourceKey: { type: 'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
@@ -19,11 +24,6 @@ module.exports = {
     //  ╠═╣╚═╗╚═╗║ ║║  ║╠═╣ ║ ║║ ║║║║╚═╗
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
-    // Other side of One-to-One
-    blobKey:{
-      model:'blobs',
-      unique: true
-    }
   },
-  datastore: "mongodb",
+  datastore: 'mongodb',
 };

--- a/api/models/Source.js
+++ b/api/models/Source.js
@@ -12,8 +12,7 @@ module.exports = {
     //  ╔═╗╦═╗╦╔╦╗╦╔╦╗╦╦  ╦╔═╗╔═╗
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
-
-    description: { type: 'string' },
+    
     base64SourceKey: { type: 'string' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗

--- a/config/routes.js
+++ b/config/routes.js
@@ -33,13 +33,13 @@ module.exports.routes = {
   'GET /api/v1/blobs/view': { action: 'blobs/view' },
   'POST /api/v1/blobs/create': { action: 'blobs/create' },
 
-  // For testing
+  // Testing purposes
   'GET /api/v1/plugin/view': { action: 'plugin/view' },
 
-  // For testing
+  // Testing purposes
   'GET /api/v1/config/view': { action: 'config/view' },
 
-  // For testing
+  // Testing purposes
   'GET /api/v1/source/view': { action: 'source/view' },
 
   /***************************************************************************

--- a/config/routes.js
+++ b/config/routes.js
@@ -33,6 +33,14 @@ module.exports.routes = {
   'GET /api/v1/blobs/view': { action: 'blobs/view' },
   'POST /api/v1/blobs/create': { action: 'blobs/create' },
 
+  // For testing
+  'GET /api/v1/plugin/view': { action: 'plugin/view' },
+
+  // For testing
+  'GET /api/v1/config/view': { action: 'config/view' },
+
+  // For testing
+  'GET /api/v1/source/view': { action: 'source/view' },
 
   /***************************************************************************
   *                                                                          *

--- a/package-lock.json
+++ b/package-lock.json
@@ -6951,6 +6951,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "uglify-js": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA=="
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6956,11 +6956,6 @@
         "mime-types": "~2.1.24"
       }
     },
-    "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA=="
-    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -541,6 +541,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
+    },
     "csrf": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "sails-hook-grunt": "^4.0.0",
     "sails-hook-orm": "^2.1.1",
     "sails-hook-sockets": "^2.0.0",
-    "sails-mongo": "^1.2.0"
+    "sails-mongo": "^1.2.0",
+    "uglify-js": "^3.10.0"
   },
   "devDependencies": {
     "eslint": "5.16.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@sailshq/lodash": "^3.10.3",
     "@sailshq/socket.io-redis": "^5.2.0",
     "base64url": "^3.0.1",
+    "crypto": "^1.0.1",
     "grunt": "1.0.4",
     "sails": "^1.2.4",
     "sails-hook-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "sails-hook-grunt": "^4.0.0",
     "sails-hook-orm": "^2.1.1",
     "sails-hook-sockets": "^2.0.0",
-    "sails-mongo": "^1.2.0",
-    "uglify-js": "^3.10.0"
+    "sails-mongo": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "5.16.0"

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Babel Codesandbox Server
+# babel-sandbox-server
 
 a [Sails v1](https://sailsjs.com) application
 
@@ -33,13 +33,3 @@ This app was originally generated on Mon Jul 27 2020 13:07:39 GMT-0500 (Central 
 Note:  Generators are usually run using the globally-installed `sails` CLI (command-line interface).  This CLI version is _environment-specific_ rather than app-specific, thus over time, as a project's dependencies are upgraded or the project is worked on by different developers on different computers using different versions of Node.js, the Sails dependency in its package.json file may differ from the globally-installed Sails CLI release it was originally generated with.  (Be sure to always check out the relevant [upgrading guides](https://sailsjs.com/upgrading) before upgrading the version of Sails used by your app.  If you're stuck, [get help here](https://sailsjs.com/support).)
 -->
 
-
-
-A (wrong) test of the Snippet().ID() stuff
-
-```js
-let leftPadSource = `!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{("undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this).leftPad=e()}}(function(){return function(){return function e(n,r,t){function f(i,u){if(!r[i]){if(!n[i]){var d="function"==typeof require&&require;if(!u&&d)return d(i,!0);if(o)return o(i,!0);var l=new Error("Cannot find module '"+i+"'");throw l.code="MODULE_NOT_FOUND",l}var c=r[i]={exports:{}};n[i][0].call(c.exports,function(e){return f(n[i][1][e]||e)},c,c.exports,e,n,r,t)}return r[i].exports}for(var o="function"==typeof require&&require,i=0;i<t.length;i++)f(t[i]);return f}}()({1:[function(e,n,r){"use strict";n.exports=function(e,n,r){if((n-=(e+="").length)<=0)return e;r||0===r||(r=" ");if(" "==(r+="")&&n<10)return t[n]+e;var f="";for(;1&n&&(f+=r),n>>=1;)r+=r;return f+e};var t=[""," ","  ","   ","    ","     ","      ","       ","        ","         "]},{}]},{},[1])(1)});`;
-let exampleJsFile = `function msg(){ alert("Hello Javatpoint");}`;
-
-console.log(new Snippet(exampleJsFile, leftPadSource, ['test1', 'test2']).ID());
-```

--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,33 @@
 a [Sails v1](https://sailsjs.com) application
 
 
-```js
-let leftPadSource = `!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{("undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this).leftPad=e()}}(function(){return function(){return function e(n,r,t){function f(i,u){if(!r[i]){if(!n[i]){var d="function"==typeof require&&require;if(!u&&d)return d(i,!0);if(o)return o(i,!0);var l=new Error("Cannot find module '"+i+"'");throw l.code="MODULE_NOT_FOUND",l}var c=r[i]={exports:{}};n[i][0].call(c.exports,function(e){return f(n[i][1][e]||e)},c,c.exports,e,n,r,t)}return r[i].exports}for(var o="function"==typeof require&&require,i=0;i<t.length;i++)f(t[i]);return f}}()({1:[function(e,n,r){"use strict";n.exports=function(e,n,r){if((n-=(e+="").length)<=0)return e;r||0===r||(r=" ");if(" "==(r+="")&&n<10)return t[n]+e;var f="";for(;1&n&&(f+=r),n>>=1;)r+=r;return f+e};var t=[""," ","  ","   ","    ","     ","      ","       ","        ","         "]},{}]},{},[1])(1)});`;
-let exampleJsFile = `function msg(){ alert("Hello Javatpoint");}`;
+### Links
 
-console.log(
-  new Snippet(exampleJsFile, leftPadSource, ["test1", "test2"]).Link(),
-  Snippet.ID(exampleJsFile)
-);
-```
++ [Sails framework documentation](https://sailsjs.com/get-started)
++ [Version notes / upgrading](https://sailsjs.com/documentation/upgrading)
++ [Deployment tips](https://sailsjs.com/documentation/concepts/deployment)
++ [Community support options](https://sailsjs.com/support)
++ [Professional / enterprise options](https://sailsjs.com/enterprise)
+
+### Quick Start
++ Install [MongoDB](https://www.mongodb.com/try/download/community)
++ Install Sails.js: `npm install -g sails`
++ Install dependencies: `npm install`
++ Run: `sails lift` or `sails lift --port NUMBER` if you encounter `EADDRINUSE`
++ Open [Postman](https://www.postman.com/downloads/)
++ Create a new POST request
++ Enter: `http://localhost:1337/api/v1/config/update` and click Send
++ Expected output: `status 200 ok`
+
+### Version info
+
+This app was originally generated on Mon Jul 27 2020 13:07:39 GMT-0500 (Central Daylight Time) using Sails v1.2.4.
+
+<!-- Internally, Sails used [`sails-generate@1.17.2`](https://github.com/balderdashy/sails-generate/tree/v1.17.2/lib/core-generators/new). -->
+
+
+
+<!--
+Note:  Generators are usually run using the globally-installed `sails` CLI (command-line interface).  This CLI version is _environment-specific_ rather than app-specific, thus over time, as a project's dependencies are upgraded or the project is worked on by different developers on different computers using different versions of Node.js, the Sails dependency in its package.json file may differ from the globally-installed Sails CLI release it was originally generated with.  (Be sure to always check out the relevant [upgrading guides](https://sailsjs.com/upgrading) before upgrading the version of Sails used by your app.  If you're stuck, [get help here](https://sailsjs.com/support).)
+-->
+

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,10 @@
 a [Sails v1](https://sailsjs.com) application
 
 
+```js
+let leftPadSource = `!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{("undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this).leftPad=e()}}(function(){return function(){return function e(n,r,t){function f(i,u){if(!r[i]){if(!n[i]){var d="function"==typeof require&&require;if(!u&&d)return d(i,!0);if(o)return o(i,!0);var l=new Error("Cannot find module '"+i+"'");throw l.code="MODULE_NOT_FOUND",l}var c=r[i]={exports:{}};n[i][0].call(c.exports,function(e){return f(n[i][1][e]||e)},c,c.exports,e,n,r,t)}return r[i].exports}for(var o="function"==typeof require&&require,i=0;i<t.length;i++)f(t[i]);return f}}()({1:[function(e,n,r){"use strict";n.exports=function(e,n,r){if((n-=(e+="").length)<=0)return e;r||0===r||(r=" ");if(" "==(r+="")&&n<10)return t[n]+e;var f="";for(;1&n&&(f+=r),n>>=1;)r+=r;return f+e};var t=[""," ","  ","   ","    ","     ","      ","       ","        ","         "]},{}]},{},[1])(1)});`;
+let exampleJsFile = `function msg(){ alert("Hello Javatpoint");}`;
+
 console.log(
   new Snippet(exampleJsFile, leftPadSource, ["test1", "test2"]).Link(),
   Snippet.ID(exampleJsFile)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,40 @@
 # Babel Codesandbox Server
 
+a [Sails v1](https://sailsjs.com) application
+
+
+### Links
+
++ [Sails framework documentation](https://sailsjs.com/get-started)
++ [Version notes / upgrading](https://sailsjs.com/documentation/upgrading)
++ [Deployment tips](https://sailsjs.com/documentation/concepts/deployment)
++ [Community support options](https://sailsjs.com/support)
++ [Professional / enterprise options](https://sailsjs.com/enterprise)
+
+### Quick Start
++ Install [MongoDB](https://www.mongodb.com/try/download/community)
++ Install Sails.js: `npm install -g sails`
++ Install dependencies: `npm install`
++ Run: `sails lift` or `sails lift --port NUMBER` if you encounter `EADDRINUSE`
++ Open [Postman](https://www.postman.com/downloads/)
++ Create a new POST request
++ Enter: `http://localhost:1337/api/v1/config/update` and click Send
++ Expected output: `status 200 ok`
+
+### Version info
+
+This app was originally generated on Mon Jul 27 2020 13:07:39 GMT-0500 (Central Daylight Time) using Sails v1.2.4.
+
+<!-- Internally, Sails used [`sails-generate@1.17.2`](https://github.com/balderdashy/sails-generate/tree/v1.17.2/lib/core-generators/new). -->
+
+
+
+<!--
+Note:  Generators are usually run using the globally-installed `sails` CLI (command-line interface).  This CLI version is _environment-specific_ rather than app-specific, thus over time, as a project's dependencies are upgraded or the project is worked on by different developers on different computers using different versions of Node.js, the Sails dependency in its package.json file may differ from the globally-installed Sails CLI release it was originally generated with.  (Be sure to always check out the relevant [upgrading guides](https://sailsjs.com/upgrading) before upgrading the version of Sails used by your app.  If you're stuck, [get help here](https://sailsjs.com/support).)
+-->
+
+
+
 A (wrong) test of the Snippet().ID() stuff
 
 ```js


### PR DESCRIPTION
This PR adds endpoints that accepts a JSON blob with the source code, plugin code and configs encoded as base 64 string and persists them to a mongoDB database. I think this would close [#25](https://github.com/MLH-Fellowship/babel-sandbox/issues/25)

Run `sails lift --drop` the first time round and without `--drop` on consequent runs
## To test
**POST** `http://localhost:1337/api/v1/blobs/create` like so
```JSON
{
  "source": "Y29uc29sZS5sb2coImhlbGxvIHdvcmxkIik=",
  "plugin": "e30=",
  "configs": [
    "eyJmb28iOiJiYXIifQ==",
    "eyJiYXoiOiAicXV4In0="
  ]
}
```
![image](https://user-images.githubusercontent.com/32067562/88987115-e5ca5980-d2a2-11ea-952f-152e00d4b85c.png)

Changing even a single letter in any of `source`, `plugin`, `config[...]` should result in another `blob` being made and another `{source, plugin, configs[...]}`  which can be tested with the appropriate **GET** request

Check if the `{ source, plugin, configs[...] }` have been added using:
**GET** `http://localhost:1337/api/v1/blobs/view`
**GET** `http://localhost:1337/api/v1/source/view`
**GET** `http://localhost:1337/api/v1/plugin/view`
**GET** `http://localhost:1337/api/v1/config/view`


