### PR TITLE
Update Sails security policy to enable CORS (for now)

### DIFF
--- a/config/security.js
+++ b/config/security.js
@@ -28,11 +28,11 @@ module.exports.security = {
   *                                                                          *
   ***************************************************************************/
 
-  // cors: {
-  //   allRoutes: false,
-  //   allowOrigins: '*',
-  //   allowCredentials: false,
-  // },
+  cors: {
+    allRoutes: true,
+    allowOrigins: '*',
+    allowCredentials: false,
+  },
 
 
   /****************************************************************************

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "sails": "^1.2.4",
     "sails-hook-grunt": "^4.0.0",
     "sails-hook-orm": "^2.1.1",
+    "sails-hook-requestlogger": "^1.0.0",
     "sails-hook-sockets": "^2.0.0",
     "sails-mongo": "^1.2.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,9 @@ a [Sails v1](https://sailsjs.com) application
 + Install dependencies: `npm install`
 + Run: `sails lift`.
 + The server is now running on port `1337`
-+ 
++ Run [The Babel Sandbox](https://github.com/MLH-Fellowship/babel-sandbox)
+
+### Testing
 + Open [Postman](https://www.postman.com/downloads/)
 + Create a new POST request
 + Enter: `http://localhost:1337/api/v1/config/update` and click Send

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,9 @@ a [Sails v1](https://sailsjs.com) application
 + Install [MongoDB](https://www.mongodb.com/try/download/community)
 + Install Sails.js: `npm install -g sails`
 + Install dependencies: `npm install`
-+ Run: `sails lift` or `sails lift --port NUMBER` if you encounter `EADDRINUSE`
++ Run: `sails lift`.
++ The server is now running on port `1337`
++ 
 + Open [Postman](https://www.postman.com/downloads/)
 + Create a new POST request
 + Enter: `http://localhost:1337/api/v1/config/update` and click Send


### PR DESCRIPTION
This pull adds `requestlogger` module that outputs every request made:

```
GET /styles/importer.css 200 2.939 ms - 528
GET /dependencies/sails.io.js 304 1.322 ms - -
GET /favicon.ico 200 0.604 ms - 920
debug: Creating blob
POST /api/v1/blobs/create 200 96.527 ms - 249
debug: Successfully created new blob
^Cverbo: Lowering sails...
     : Sent kill signal to child process (2668)...
     : Shutting down HTTP server...
     : HTTP server shut down successfully.
```

It also enables `cors` for testing and documents the setup process so we can merge https://github.com/MLH-Fellowship/babel-sandbox/pull/38