### PR TITLE
Add GET endpoints

### DIFF
--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -34,7 +34,7 @@ module.exports = {
     const newBlob = await Blobs.create().fetch();
     
     // Add shareble link to response body
-    newBlob.url = `http://localhost:1337/share/${newBlob.id}`;
+    newBlob.url = `http://localhost:${sails.config.port}/share/${newBlob.id}`;
 
     // Check for Plugin and add if not present
     const newPlugin = await Plugin.findOrCreate(

--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -1,5 +1,3 @@
-const { Snippet } = require("../../../snippet");
-const crypto = require("crypto");
 module.exports = {
   friendlyName: "Create new blob test",
 
@@ -32,17 +30,11 @@ module.exports = {
   fn: async ({ source, plugin, configs }) => {
     sails.log("Creating blob");
 
-    const blobBase64 = crypto
-      .createHash("sha256")
-      .update(Snippet.salt)
-      .update(JSON.stringify({ source, plugin, configs }))
-      .digest("hex");
-
     // Check for Blob and add if not present
-    const newBlob = await Blobs.findOrCreate(
-      { base64BlobKey: blobBase64 },
-      { base64BlobKey: blobBase64 }
-    );
+    const newBlob = await Blobs.create().fetch();
+    
+    // Add shareble link to response body
+    newBlob.url = `http://localhost:1337/share/${newBlob.id}`;
 
     // Check for Plugin and add if not present
     const newPlugin = await Plugin.findOrCreate(
@@ -83,6 +75,6 @@ module.exports = {
     });
 
     // TODO: Add a return; problem: the fields "source" and "plugin" show up as null :(
-    return { blob: newBlob };
+    return _.omit(newBlob, 'source', 'plugin');
   },
 };

--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -74,7 +74,7 @@ module.exports = {
       );
     });
 
-    // TODO: Add a return; problem: the fields "source" and "plugin" show up as null :(
+    // Return newly created blob, omit the `source` and `plugin` fields
     return _.omit(newBlob, 'source', 'plugin');
   },
 };

--- a/api/controllers/blobs/create.js
+++ b/api/controllers/blobs/create.js
@@ -32,9 +32,9 @@ module.exports = {
 
     // Check for Blob and add if not present
     const newBlob = await Blobs.create().fetch();
-    
+
     // Add shareble link to response body
-    newBlob.url = `http://localhost:${sails.config.port}/share/${newBlob.id}`;
+    newBlob.url = `/share/${newBlob.id}`;
 
     // Check for Plugin and add if not present
     const newPlugin = await Plugin.findOrCreate(

--- a/api/controllers/blobs/get-blob.js
+++ b/api/controllers/blobs/get-blob.js
@@ -1,0 +1,44 @@
+module.exports = {
+  friendlyName: "TestFriendlyName",
+  description: "Test description",
+  inputs: {
+    id: {
+      description: "The id of the blob we're retrieving",
+      type: "string",
+      required: true,
+    },
+  },
+
+  exits: {
+    success: {
+      outputDescription: "Blob and associated fields",
+      outputType: "ref",
+    },
+    forbidden: { responseType: "forbidden" },
+    notFound: { responseType: "notFound" },
+  },
+
+  fn: async ({ id }) => {
+    sails.log(`Retrieving blob with id ${id}`);
+    let responseBody = {};
+    await Blobs.findOne({ id })
+      .populate("source")
+      .then(
+        ({ source }) => (responseBody.base64SourceKey = source.base64SourceKey)
+      );
+    await Blobs.findOne({ id })
+      .populate("plugin")
+      .then(
+        ({ plugin }) => (responseBody.base64PluginKey = plugin.base64PluginKey)
+      );
+    await Blobs.findOne({ id })
+      .populate("configs")
+      .then(
+        ({ configs }) =>
+          (responseBody.configIDs = configs.map(
+            (config) => config.base64ConfigKey
+          ))
+      );
+    return responseBody;
+  },
+};

--- a/api/controllers/blobs/get-blob.js
+++ b/api/controllers/blobs/get-blob.js
@@ -1,9 +1,9 @@
 module.exports = {
-  friendlyName: "TestFriendlyName",
-  description: "Test description",
+  friendlyName: "Retrieve a blob",
+  description: "Endpoint to get blob info using its ID",
   inputs: {
     id: {
-      description: "The id of the blob we're retrieving",
+      description: "The ID of the blob we're retrieving",
       type: "string",
       required: true,
     },
@@ -15,22 +15,36 @@ module.exports = {
       outputType: "ref",
     },
     forbidden: { responseType: "forbidden" },
-    notFound: { responseType: "notFound" },
+    notFound: {
+      description: 'The requested ID does not exist',
+      responseType: 'notFound'
+    },
   },
 
   fn: async ({ id }) => {
-    sails.log(`Retrieving blob with id ${id}`);
-    let responseBody = {};
+    sails.log(`Retrieving blob with ID ${id}`);
+
+    // Initialize response body
+    const responseBody = {};
+
+    // Check if blob with { id } exists
+    if (!(await Blobs.findOne({ id }))) throw 'notFound';
+
+    // Add source in base 64 to response body
     await Blobs.findOne({ id })
       .populate("source")
       .then(
         ({ source }) => (responseBody.base64SourceKey = source.base64SourceKey)
       );
+
+    // Add plugin in base 64 to response body
     await Blobs.findOne({ id })
       .populate("plugin")
       .then(
         ({ plugin }) => (responseBody.base64PluginKey = plugin.base64PluginKey)
       );
+
+    // Add configs in base 64 to response body
     await Blobs.findOne({ id })
       .populate("configs")
       .then(

--- a/api/models/Blobs.js
+++ b/api/models/Blobs.js
@@ -11,8 +11,6 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
-    base64BlobKey: { type:'string' },
-
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
     //  ╚═╝╩ ╩╚═╝╚═╝═╩╝╚═╝
@@ -34,7 +32,7 @@ module.exports = {
     // One-to-Many (see file:api/models/Config.js)
     configs: {
       collection: 'config',
-      via: 'blobKey',
+      via: 'blobKeys',
     },
   },
   datastore: 'mongodb',

--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -25,8 +25,9 @@ module.exports = {
     //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
 
     // Other side of One-to-Many
-    blobKey: {
-      model: 'blobs'
+    blobKeys: {
+      collection: 'blobs',
+      via: 'configs'
     }
 
   },

--- a/config/routes.js
+++ b/config/routes.js
@@ -24,24 +24,25 @@ module.exports.routes = {
   //  ╚╩╝╚═╝╚═╝╩  ╩ ╩╚═╝╚═╝╚═╝
 
   // No apparent use for webpages right now...
-  '/': { view: 'pages/homepage' },
+  '/':                                    { view: 'pages/homepage' },
 
   //  ╔═╗╔═╗╦  ╔═╗╔╗╔╔╦╗╔═╗╔═╗╦╔╗╔╔╦╗╔═╗
   //  ╠═╣╠═╝║  ║╣ ║║║ ║║╠═╝║ ║║║║║ ║ ╚═╗
   //  ╩ ╩╩  ╩  ╚═╝╝╚╝═╩╝╩  ╚═╝╩╝╚╝ ╩ ╚═╝
 
-  'GET /api/v1/blobs/view': { action: 'blobs/view' },
-  'POST /api/v1/blobs/create': { action: 'blobs/create' },
-  'GET /api/v1/blobs/get-blob/:id': { action: 'blobs/get-blob' },
+  'GET /api/v1/blobs/view':               { action: 'blobs/view' },
+  'POST /api/v1/blobs/create':            { action: 'blobs/create' },
+  'GET /api/v1/blobs/get-blob/:id':       { action: 'blobs/get-blob' },
+  'GET /share/:id':                       { action: 'blobs/get-blob' },
 
   // Testing purposes
-  'GET /api/v1/plugin/view': { action: 'plugin/view' },
+  'GET /api/v1/plugin/view':              { action: 'plugin/view' },
 
   // Testing purposes
-  'GET /api/v1/config/view': { action: 'config/view' },
+  'GET /api/v1/config/view':              { action: 'config/view' },
 
   // Testing purposes
-  'GET /api/v1/source/view': { action: 'source/view' },
+  'GET /api/v1/source/view':              { action: 'source/view' },
 
   /***************************************************************************
   *                                                                          *

--- a/config/routes.js
+++ b/config/routes.js
@@ -32,6 +32,7 @@ module.exports.routes = {
 
   'GET /api/v1/blobs/view': { action: 'blobs/view' },
   'POST /api/v1/blobs/create': { action: 'blobs/create' },
+  'GET /api/v1/blobs/get-blob/:id': { action: 'blobs/get-blob' },
 
   // Testing purposes
   'GET /api/v1/plugin/view': { action: 'plugin/view' },

--- a/config/routes.js
+++ b/config/routes.js
@@ -32,7 +32,7 @@ module.exports.routes = {
 
   'GET /api/v1/blobs/view':               { action: 'blobs/view' },
   'POST /api/v1/blobs/create':            { action: 'blobs/create' },
-  'GET /api/v1/blobs/get-blob/:id':       { action: 'blobs/get-blob' },
+  'GET /api/v1/blobs/:id':                { action: 'blobs/get-blob' },
   'GET /share/:id':                       { action: 'blobs/get-blob' },
 
   // Testing purposes


### PR DESCRIPTION
This PR adds the endpoints `/api/v1/blobs/:id` and `/share/:id` 

## Schema changes
Removed `base64BlobKey`. The key was to prevent duplicate blobs being made. However, I realized forks of blobs (feature to be implemented) start off as a duplicate and will not persist in the database if no changes are made
 
## To test
 - Import this [`JSON`](https://pastebin.com/xUfjH3fB) file into Postman (Its a collection of requests) 
 - Create some sample blobs (POST request in the collection *should* be pre-filled, just change a few characters to simulate another file)
 - Copy the blob ID into the two new GET requests 
   - Expected Result: Source, Plugin and Configs base64 represenations must be in body
 - Test an invalid blob ID by typing gibberish into the ID field of the GET requests
   - Expected Result: `Not Found` error must be thrown