### PR TITLE
Add forks to response body

### DIFF
--- a/api/controllers/blobs/get-blob.js
+++ b/api/controllers/blobs/get-blob.js
@@ -57,6 +57,16 @@ module.exports = {
             (config) => config.base64ConfigKey
           ) : null)
       );
+
+    // Add forks to response body
+    await Blobs.findOne({ id })
+      .populate('forks')
+      .then(
+        ({ forks }) =>
+          (responseBody.forks = forks ? forks.map(
+            (fork) => fork.id
+          ) : null)
+      );
     return responseBody;
   },
 };


### PR DESCRIPTION
The PR adds `forks: [...]` to the response body for the `GET /api/v1/blobs/get-blob/:id` endpoint
